### PR TITLE
Issue/14 default to calling swift

### DIFF
--- a/.bin/install
+++ b/.bin/install
@@ -1,4 +1,4 @@
 # bootstrap script to install the builder into /usr/local/bin
 
-./.make
+make
 sudo cp .build/debug/Builder /usr/local/bin/builder

--- a/Builder.xcodeproj/Docopt_Info.plist
+++ b/Builder.xcodeproj/Docopt_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Builder.xcodeproj/project.pbxproj
+++ b/Builder.xcodeproj/project.pbxproj
@@ -1,683 +1,538 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "Builder::Builder" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_33";
-         buildPhases = (
-            "OBJ_36",
-            "OBJ_41",
-         );
-         dependencies = (
-            "OBJ_43",
-         );
-         name = "Builder";
-         productName = "Builder";
-         productReference = "Builder::Builder::Product";
-         productType = "com.apple.product-type.tool";
-      };
-      "Builder::Builder::Product" = {
-         isa = "PBXFileReference";
-         path = "Builder";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "Builder::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_46";
-         buildPhases = (
-            "OBJ_49",
-         );
-         dependencies = (
-         );
-         name = "BuilderPackageDescription";
-         productName = "BuilderPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "Logger::Logger" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_51";
-         buildPhases = (
-            "OBJ_54",
-            "OBJ_62",
-         );
-         dependencies = (
-         );
-         name = "Logger";
-         productName = "Logger";
-         productReference = "Logger::Logger::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "Logger::Logger::Product" = {
-         isa = "PBXFileReference";
-         path = "Logger.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "Logger::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_64";
-         buildPhases = (
-            "OBJ_67",
-         );
-         dependencies = (
-         );
-         name = "LoggerPackageDescription";
-         productName = "LoggerPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "English";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en",
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_29";
-         projectDirPath = ".";
-         targets = (
-            "Builder::Builder",
-            "Builder::SwiftPMPackageDescription",
-            "Logger::Logger",
-            "Logger::SwiftPMPackageDescription",
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_11",
-            "OBJ_12",
-            "OBJ_13",
-            "OBJ_14",
-         );
-         name = "Builder";
-         path = "Sources/Builder";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_11" = {
-         isa = "PBXFileReference";
-         path = "Builder.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_12" = {
-         isa = "PBXFileReference";
-         path = "Configuration.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_13" = {
-         isa = "PBXFileReference";
-         path = "Failure.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_14" = {
-         isa = "PBXFileReference";
-         path = "main.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_15" = {
-         isa = "PBXGroup";
-         children = (
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_16" = {
-         isa = "PBXFileReference";
-         path = "Example";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_17" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_18",
-         );
-         name = "Dependencies";
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_18" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_19",
-            "OBJ_27",
-            "OBJ_28",
-         );
-         name = "Logger 1.0.5";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_19" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_20",
-            "OBJ_21",
-            "OBJ_22",
-            "OBJ_23",
-            "OBJ_24",
-            "OBJ_25",
-            "OBJ_26",
-         );
-         name = "Logger";
-         path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Logger";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_20" = {
-         isa = "PBXFileReference";
-         path = "Context.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_21" = {
-         isa = "PBXFileReference";
-         path = "Handler.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_22" = {
-         isa = "PBXFileReference";
-         path = "Logger.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_23" = {
-         isa = "PBXFileReference";
-         path = "Manager.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_24" = {
-         isa = "PBXFileReference";
-         path = "NSLogHandler.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_25" = {
-         isa = "PBXFileReference";
-         path = "OSLogHandler.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_26" = {
-         isa = "PBXFileReference";
-         path = "PrintHandler.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_27" = {
-         isa = "PBXGroup";
-         children = (
-         );
-         name = "Example";
-         path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Example";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_28" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/Logger.git-7968172881489479458/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_29" = {
-         isa = "PBXGroup";
-         children = (
-            "Logger::Logger::Product",
-            "Builder::Builder::Product",
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode",
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_33" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_34",
-            "OBJ_35",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_34" = {
-         isa = "XCBuildConfiguration";
-         baseConfigurationReference = "OBJ_8";
-         buildSettings = {
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "Builder.xcodeproj/Builder_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-               "@executable_path",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
-            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Builder";
-         };
-         name = "Debug";
-      };
-      "OBJ_35" = {
-         isa = "XCBuildConfiguration";
-         baseConfigurationReference = "OBJ_8";
-         buildSettings = {
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "Builder.xcodeproj/Builder_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-               "@executable_path",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
-            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Builder";
-         };
-         name = "Release";
-      };
-      "OBJ_36" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_37",
-            "OBJ_38",
-            "OBJ_39",
-            "OBJ_40",
-         );
-      };
-      "OBJ_37" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
-      };
-      "OBJ_38" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
-      };
-      "OBJ_39" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode",
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator",
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE";
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_40" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
-      };
-      "OBJ_41" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_42",
-         );
-      };
-      "OBJ_42" = {
-         isa = "PBXBuildFile";
-         fileRef = "Logger::Logger::Product";
-      };
-      "OBJ_43" = {
-         isa = "PBXTargetDependency";
-         target = "Logger::Logger";
-      };
-      "OBJ_46" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_47",
-            "OBJ_48",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_47" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk",
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_48" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk",
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_49" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_50",
-         );
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_9",
-            "OBJ_15",
-            "OBJ_16",
-            "OBJ_17",
-            "OBJ_29",
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_50" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_51" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_52",
-            "OBJ_53",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_52" = {
-         isa = "XCBuildConfiguration";
-         baseConfigurationReference = "OBJ_8";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "Builder.xcodeproj/Logger_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Logger";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Logger";
-         };
-         name = "Debug";
-      };
-      "OBJ_53" = {
-         isa = "XCBuildConfiguration";
-         baseConfigurationReference = "OBJ_8";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks",
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)",
-            );
-            INFOPLIST_FILE = "Builder.xcodeproj/Logger_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)",
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Logger";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Logger";
-         };
-         name = "Release";
-      };
-      "OBJ_54" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_55",
-            "OBJ_56",
-            "OBJ_57",
-            "OBJ_58",
-            "OBJ_59",
-            "OBJ_60",
-            "OBJ_61",
-         );
-      };
-      "OBJ_55" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
-      };
-      "OBJ_56" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
-      };
-      "OBJ_57" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
-      };
-      "OBJ_58" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_23";
-      };
-      "OBJ_59" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
-      };
-      "OBJ_61" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
-      };
-      "OBJ_62" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_64" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_65",
-            "OBJ_66",
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_65" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk",
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_66" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk",
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_67" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_68",
-         );
-      };
-      "OBJ_68" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-         );
-         name = "Configs";
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_8" = {
-         isa = "PBXFileReference";
-         path = "Builder.xcconfig";
-         sourceTree = "<group>";
-      };
-      "OBJ_9" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_10",
-         );
-         name = "Sources";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		229E1A0520501C9C00B07600 /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229E1A0420501C9C00B07600 /* Arguments.swift */; };
+		OBJ_37 /* Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Builder.swift */; };
+		OBJ_38 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Configuration.swift */; };
+		OBJ_39 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Failure.swift */; };
+		OBJ_40 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* main.swift */; };
+		OBJ_42 /* Logger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Logger::Logger::Product" /* Logger.framework */; };
+		OBJ_50 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_55 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Context.swift */; };
+		OBJ_56 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Handler.swift */; };
+		OBJ_57 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Logger.swift */; };
+		OBJ_58 /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Manager.swift */; };
+		OBJ_59 /* NSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* NSLogHandler.swift */; };
+		OBJ_60 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* OSLogHandler.swift */; };
+		OBJ_61 /* PrintHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* PrintHandler.swift */; };
+		OBJ_68 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* Package.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		229E1A0320501C6800B07600 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Logger::Logger";
+			remoteInfo = Logger;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		229E1A0420501C9C00B07600 /* Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
+		"Builder::Builder::Product" /* Builder */ = {isa = PBXFileReference; lastKnownFileType = text; path = Builder; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Logger::Logger::Product" /* Logger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Logger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_11 /* Builder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Builder.swift; sourceTree = "<group>"; };
+		OBJ_12 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		OBJ_13 /* Failure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
+		OBJ_14 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		OBJ_16 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_20 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
+		OBJ_21 /* Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handler.swift; sourceTree = "<group>"; };
+		OBJ_22 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		OBJ_23 /* Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.swift; sourceTree = "<group>"; };
+		OBJ_24 /* NSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLogHandler.swift; sourceTree = "<group>"; };
+		OBJ_25 /* OSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogHandler.swift; sourceTree = "<group>"; };
+		OBJ_26 /* PrintHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintHandler.swift; sourceTree = "<group>"; };
+		OBJ_28 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/Logger.git-7968172881489479458/Package.swift"; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_8 /* Builder.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Builder.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_41 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_42 /* Logger.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_62 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_10 /* Builder */ = {
+			isa = PBXGroup;
+			children = (
+				229E1A0420501C9C00B07600 /* Arguments.swift */,
+				OBJ_11 /* Builder.swift */,
+				OBJ_12 /* Configuration.swift */,
+				OBJ_13 /* Failure.swift */,
+				OBJ_14 /* main.swift */,
+			);
+			name = Builder;
+			path = Sources/Builder;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_15 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_17 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_18 /* Logger 1.0.5 */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		OBJ_18 /* Logger 1.0.5 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_19 /* Logger */,
+				OBJ_27 /* Example */,
+				OBJ_28 /* Package.swift */,
+			);
+			name = "Logger 1.0.5";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_19 /* Logger */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_20 /* Context.swift */,
+				OBJ_21 /* Handler.swift */,
+				OBJ_22 /* Logger.swift */,
+				OBJ_23 /* Manager.swift */,
+				OBJ_24 /* NSLogHandler.swift */,
+				OBJ_25 /* OSLogHandler.swift */,
+				OBJ_26 /* PrintHandler.swift */,
+			);
+			name = Logger;
+			path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Logger";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_27 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Example;
+			path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Example";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_29 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"Logger::Logger::Product" /* Logger.framework */,
+				"Builder::Builder::Product" /* Builder */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Configs */,
+				OBJ_9 /* Sources */,
+				OBJ_15 /* Tests */,
+				OBJ_16 /* Example */,
+				OBJ_17 /* Dependencies */,
+				OBJ_29 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* Builder.xcconfig */,
+			);
+			name = Configs;
+			sourceTree = "<group>";
+		};
+		OBJ_9 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* Builder */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"Builder::Builder" /* Builder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_33 /* Build configuration list for PBXNativeTarget "Builder" */;
+			buildPhases = (
+				OBJ_36 /* Sources */,
+				OBJ_41 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_43 /* PBXTargetDependency */,
+			);
+			name = Builder;
+			productName = Builder;
+			productReference = "Builder::Builder::Product" /* Builder */;
+			productType = "com.apple.product-type.tool";
+		};
+		"Builder::SwiftPMPackageDescription" /* BuilderPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_46 /* Build configuration list for PBXNativeTarget "BuilderPackageDescription" */;
+			buildPhases = (
+				OBJ_49 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BuilderPackageDescription;
+			productName = BuilderPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"Logger::Logger" /* Logger */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_51 /* Build configuration list for PBXNativeTarget "Logger" */;
+			buildPhases = (
+				OBJ_54 /* Sources */,
+				OBJ_62 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Logger;
+			productName = Logger;
+			productReference = "Logger::Logger::Product" /* Logger.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Logger::SwiftPMPackageDescription" /* LoggerPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_64 /* Build configuration list for PBXNativeTarget "LoggerPackageDescription" */;
+			buildPhases = (
+				OBJ_67 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LoggerPackageDescription;
+			productName = LoggerPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Builder" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_29 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"Builder::Builder" /* Builder */,
+				"Builder::SwiftPMPackageDescription" /* BuilderPackageDescription */,
+				"Logger::Logger" /* Logger */,
+				"Logger::SwiftPMPackageDescription" /* LoggerPackageDescription */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_36 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				229E1A0520501C9C00B07600 /* Arguments.swift in Sources */,
+				OBJ_37 /* Builder.swift in Sources */,
+				OBJ_38 /* Configuration.swift in Sources */,
+				OBJ_39 /* Failure.swift in Sources */,
+				OBJ_40 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_49 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_50 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_55 /* Context.swift in Sources */,
+				OBJ_56 /* Handler.swift in Sources */,
+				OBJ_57 /* Logger.swift in Sources */,
+				OBJ_58 /* Manager.swift in Sources */,
+				OBJ_59 /* NSLogHandler.swift in Sources */,
+				OBJ_60 /* OSLogHandler.swift in Sources */,
+				OBJ_61 /* PrintHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_67 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_68 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_43 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Logger::Logger" /* Logger */;
+			targetProxy = 229E1A0320501C6800B07600 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Builder_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Builder;
+			};
+			name = Debug;
+		};
+		OBJ_35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Builder_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Builder;
+			};
+			name = Release;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_47 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_48 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_52 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Logger_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Logger;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Logger;
+			};
+			name = Debug;
+		};
+		OBJ_53 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Logger_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Logger;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Logger;
+			};
+			name = Release;
+		};
+		OBJ_65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_2 /* Build configuration list for PBXProject "Builder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_33 /* Build configuration list for PBXNativeTarget "Builder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_34 /* Debug */,
+				OBJ_35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_46 /* Build configuration list for PBXNativeTarget "BuilderPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_47 /* Debug */,
+				OBJ_48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_51 /* Build configuration list for PBXNativeTarget "Logger" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_52 /* Debug */,
+				OBJ_53 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_64 /* Build configuration list for PBXNativeTarget "LoggerPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_65 /* Debug */,
+				OBJ_66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/Builder.xcodeproj/project.pbxproj
+++ b/Builder.xcodeproj/project.pbxproj
@@ -6,20 +6,6 @@
 	objectVersion = 46;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		"Builder::builder::ProductTarget" /* builder */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_119 /* Build configuration list for PBXAggregateTarget "builder" */;
-			buildPhases = (
-			);
-			dependencies = (
-				OBJ_122 /* PBXTargetDependency */,
-			);
-			name = builder;
-			productName = builder;
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		OBJ_104 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* Context.swift */; };
 		OBJ_105 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* Handler.swift */; };
@@ -56,26 +42,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		229E1A0A20503C2100B07600 /* PBXContainerItemProxy */ = {
+		229E1A11205052D000B07600 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Logger::Logger";
 			remoteInfo = Logger;
 		};
-		229E1A0B20503C2100B07600 /* PBXContainerItemProxy */ = {
+		229E1A12205052D000B07600 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Docopt::Docopt";
 			remoteInfo = Docopt;
-		};
-		229E1A0C20503C2100B07600 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Builder::Builder";
-			remoteInfo = Builder;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -89,7 +68,7 @@
 		OBJ_14 /* Failure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
 		OBJ_15 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		OBJ_17 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
-		OBJ_20 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/docopt.swift--6086311741592416371/Package.swift"; sourceTree = "<group>"; };
+		OBJ_20 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/docopt.swift--1782864774762841802/Package.swift"; sourceTree = "<group>"; };
 		OBJ_21 /* Argument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
 		OBJ_22 /* BranchPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPattern.swift; sourceTree = "<group>"; };
 		OBJ_23 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
@@ -112,7 +91,7 @@
 		OBJ_42 /* NSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLogHandler.swift; sourceTree = "<group>"; };
 		OBJ_43 /* OSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogHandler.swift; sourceTree = "<group>"; };
 		OBJ_44 /* PrintHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintHandler.swift; sourceTree = "<group>"; };
-		OBJ_46 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/Logger.git-7968172881489479458/Package.swift"; sourceTree = "<group>"; };
+		OBJ_46 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/Logger-4601860711490015212/Package.swift"; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_8 /* Builder.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Builder.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -168,7 +147,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_19 /* Docopt 0.6.7 */,
-				OBJ_36 /* Logger 1.0.5 */,
+				OBJ_36 /* Logger 1.0.6 */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
@@ -194,17 +173,17 @@
 				OBJ_35 /* Tokens.swift */,
 			);
 			name = "Docopt 0.6.7";
-			path = ".build/checkouts/docopt.swift--6086311741592416371/Sources";
+			path = ".build/checkouts/docopt.swift--1782864774762841802/Sources";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_36 /* Logger 1.0.5 */ = {
+		OBJ_36 /* Logger 1.0.6 */ = {
 			isa = PBXGroup;
 			children = (
 				OBJ_37 /* Logger */,
 				OBJ_45 /* Example */,
 				OBJ_46 /* Package.swift */,
 			);
-			name = "Logger 1.0.5";
+			name = "Logger 1.0.6";
 			sourceTree = SOURCE_ROOT;
 		};
 		OBJ_37 /* Logger */ = {
@@ -219,7 +198,7 @@
 				OBJ_44 /* PrintHandler.swift */,
 			);
 			name = Logger;
-			path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Logger";
+			path = ".build/checkouts/Logger-4601860711490015212/Sources/Logger";
 			sourceTree = SOURCE_ROOT;
 		};
 		OBJ_45 /* Example */ = {
@@ -227,15 +206,15 @@
 			children = (
 			);
 			name = Example;
-			path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Example";
+			path = ".build/checkouts/Logger-4601860711490015212/Sources/Example";
 			sourceTree = SOURCE_ROOT;
 		};
 		OBJ_47 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				"Logger::Logger::Product" /* Logger.framework */,
-				"Builder::Builder::Product" /* Builder */,
 				"Docopt::Docopt::Product" /* Docopt.framework */,
+				"Builder::Builder::Product" /* Builder */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -391,7 +370,6 @@
 				"Docopt::SwiftPMPackageDescription" /* DocoptPackageDescription */,
 				"Logger::Logger" /* Logger */,
 				"Logger::SwiftPMPackageDescription" /* LoggerPackageDescription */,
-				"Builder::builder::ProductTarget" /* builder */,
 			);
 		};
 /* End PBXProject section */
@@ -472,20 +450,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_122 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Builder::Builder" /* Builder */;
-			targetProxy = 229E1A0C20503C2100B07600 /* PBXContainerItemProxy */;
-		};
 		OBJ_64 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Logger::Logger" /* Logger */;
-			targetProxy = 229E1A0A20503C2100B07600 /* PBXContainerItemProxy */;
+			targetProxy = 229E1A11205052D000B07600 /* PBXContainerItemProxy */;
 		};
 		OBJ_66 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Docopt::Docopt" /* Docopt */;
-			targetProxy = 229E1A0B20503C2100B07600 /* PBXContainerItemProxy */;
+			targetProxy = 229E1A12205052D000B07600 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -551,18 +524,6 @@
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
-		OBJ_120 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		OBJ_121 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
 			};
 			name = Release;
 		};
@@ -747,15 +708,6 @@
 			buildConfigurations = (
 				OBJ_114 /* Debug */,
 				OBJ_115 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_119 /* Build configuration list for PBXAggregateTarget "builder" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_120 /* Debug */,
-				OBJ_121 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Builder.xcodeproj/project.pbxproj
+++ b/Builder.xcodeproj/project.pbxproj
@@ -6,65 +6,135 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		"Builder::builder::ProductTarget" /* builder */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_119 /* Build configuration list for PBXAggregateTarget "builder" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_122 /* PBXTargetDependency */,
+			);
+			name = builder;
+			productName = builder;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
-		229E1A0520501C9C00B07600 /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229E1A0420501C9C00B07600 /* Arguments.swift */; };
-		OBJ_37 /* Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Builder.swift */; };
-		OBJ_38 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Configuration.swift */; };
-		OBJ_39 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Failure.swift */; };
-		OBJ_40 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* main.swift */; };
-		OBJ_42 /* Logger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Logger::Logger::Product" /* Logger.framework */; };
-		OBJ_50 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_55 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Context.swift */; };
-		OBJ_56 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Handler.swift */; };
-		OBJ_57 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Logger.swift */; };
-		OBJ_58 /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Manager.swift */; };
-		OBJ_59 /* NSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* NSLogHandler.swift */; };
-		OBJ_60 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* OSLogHandler.swift */; };
-		OBJ_61 /* PrintHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* PrintHandler.swift */; };
-		OBJ_68 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* Package.swift */; };
+		OBJ_104 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* Context.swift */; };
+		OBJ_105 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* Handler.swift */; };
+		OBJ_106 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* Logger.swift */; };
+		OBJ_107 /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Manager.swift */; };
+		OBJ_108 /* NSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* NSLogHandler.swift */; };
+		OBJ_109 /* OSLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* OSLogHandler.swift */; };
+		OBJ_110 /* PrintHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* PrintHandler.swift */; };
+		OBJ_117 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* Package.swift */; };
+		OBJ_56 /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Arguments.swift */; };
+		OBJ_57 /* Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Builder.swift */; };
+		OBJ_58 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Configuration.swift */; };
+		OBJ_59 /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Failure.swift */; };
+		OBJ_60 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* main.swift */; };
+		OBJ_62 /* Logger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Logger::Logger::Product" /* Logger.framework */; };
+		OBJ_63 /* Docopt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Docopt::Docopt::Product" /* Docopt.framework */; };
+		OBJ_73 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_78 /* Argument.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Argument.swift */; };
+		OBJ_79 /* BranchPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* BranchPattern.swift */; };
+		OBJ_80 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Command.swift */; };
+		OBJ_81 /* Docopt.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Docopt.swift */; };
+		OBJ_82 /* DocoptError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* DocoptError.swift */; };
+		OBJ_83 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* Either.swift */; };
+		OBJ_84 /* LeafPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* LeafPattern.swift */; };
+		OBJ_85 /* OneOrMore.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* OneOrMore.swift */; };
+		OBJ_86 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* Option.swift */; };
+		OBJ_87 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* Optional.swift */; };
+		OBJ_88 /* OptionsShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* OptionsShortcut.swift */; };
+		OBJ_89 /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* Pattern.swift */; };
+		OBJ_90 /* Required.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Required.swift */; };
+		OBJ_91 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* String.swift */; };
+		OBJ_92 /* Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* Tokens.swift */; };
+		OBJ_99 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Package.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		229E1A0320501C6800B07600 /* PBXContainerItemProxy */ = {
+		229E1A0A20503C2100B07600 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Logger::Logger";
 			remoteInfo = Logger;
 		};
+		229E1A0B20503C2100B07600 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Docopt::Docopt";
+			remoteInfo = Docopt;
+		};
+		229E1A0C20503C2100B07600 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Builder::Builder";
+			remoteInfo = Builder;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		229E1A0420501C9C00B07600 /* Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
 		"Builder::Builder::Product" /* Builder */ = {isa = PBXFileReference; lastKnownFileType = text; path = Builder; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Docopt::Docopt::Product" /* Docopt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Docopt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Logger::Logger::Product" /* Logger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Logger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		OBJ_11 /* Builder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Builder.swift; sourceTree = "<group>"; };
-		OBJ_12 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		OBJ_13 /* Failure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
-		OBJ_14 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		OBJ_16 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
-		OBJ_20 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
-		OBJ_21 /* Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handler.swift; sourceTree = "<group>"; };
-		OBJ_22 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		OBJ_23 /* Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.swift; sourceTree = "<group>"; };
-		OBJ_24 /* NSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLogHandler.swift; sourceTree = "<group>"; };
-		OBJ_25 /* OSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogHandler.swift; sourceTree = "<group>"; };
-		OBJ_26 /* PrintHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintHandler.swift; sourceTree = "<group>"; };
-		OBJ_28 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/Logger.git-7968172881489479458/Package.swift"; sourceTree = "<group>"; };
+		OBJ_11 /* Arguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
+		OBJ_12 /* Builder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Builder.swift; sourceTree = "<group>"; };
+		OBJ_13 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		OBJ_14 /* Failure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
+		OBJ_15 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		OBJ_17 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_20 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/docopt.swift--6086311741592416371/Package.swift"; sourceTree = "<group>"; };
+		OBJ_21 /* Argument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
+		OBJ_22 /* BranchPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPattern.swift; sourceTree = "<group>"; };
+		OBJ_23 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		OBJ_24 /* Docopt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Docopt.swift; sourceTree = "<group>"; };
+		OBJ_25 /* DocoptError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocoptError.swift; sourceTree = "<group>"; };
+		OBJ_26 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
+		OBJ_27 /* LeafPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeafPattern.swift; sourceTree = "<group>"; };
+		OBJ_28 /* OneOrMore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneOrMore.swift; sourceTree = "<group>"; };
+		OBJ_29 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
+		OBJ_30 /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
+		OBJ_31 /* OptionsShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsShortcut.swift; sourceTree = "<group>"; };
+		OBJ_32 /* Pattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pattern.swift; sourceTree = "<group>"; };
+		OBJ_33 /* Required.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Required.swift; sourceTree = "<group>"; };
+		OBJ_34 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		OBJ_35 /* Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokens.swift; sourceTree = "<group>"; };
+		OBJ_38 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
+		OBJ_39 /* Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handler.swift; sourceTree = "<group>"; };
+		OBJ_40 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		OBJ_41 /* Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.swift; sourceTree = "<group>"; };
+		OBJ_42 /* NSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLogHandler.swift; sourceTree = "<group>"; };
+		OBJ_43 /* OSLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogHandler.swift; sourceTree = "<group>"; };
+		OBJ_44 /* PrintHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintHandler.swift; sourceTree = "<group>"; };
+		OBJ_46 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/caconym/Users/sam/Projects/Builder/.build/checkouts/Logger.git-7968172881489479458/Package.swift"; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_8 /* Builder.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Builder.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		OBJ_41 /* Frameworks */ = {
+		OBJ_111 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_42 /* Logger.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_62 /* Frameworks */ = {
+		OBJ_61 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_62 /* Logger.framework in Frameworks */,
+				OBJ_63 /* Docopt.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_93 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -77,57 +147,82 @@
 		OBJ_10 /* Builder */ = {
 			isa = PBXGroup;
 			children = (
-				229E1A0420501C9C00B07600 /* Arguments.swift */,
-				OBJ_11 /* Builder.swift */,
-				OBJ_12 /* Configuration.swift */,
-				OBJ_13 /* Failure.swift */,
-				OBJ_14 /* main.swift */,
+				OBJ_11 /* Arguments.swift */,
+				OBJ_12 /* Builder.swift */,
+				OBJ_13 /* Configuration.swift */,
+				OBJ_14 /* Failure.swift */,
+				OBJ_15 /* main.swift */,
 			);
 			name = Builder;
 			path = Sources/Builder;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_15 /* Tests */ = {
+		OBJ_16 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Tests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_17 /* Dependencies */ = {
+		OBJ_18 /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_18 /* Logger 1.0.5 */,
+				OBJ_19 /* Docopt 0.6.7 */,
+				OBJ_36 /* Logger 1.0.5 */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		OBJ_18 /* Logger 1.0.5 */ = {
+		OBJ_19 /* Docopt 0.6.7 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_19 /* Logger */,
-				OBJ_27 /* Example */,
-				OBJ_28 /* Package.swift */,
+				OBJ_20 /* Package.swift */,
+				OBJ_21 /* Argument.swift */,
+				OBJ_22 /* BranchPattern.swift */,
+				OBJ_23 /* Command.swift */,
+				OBJ_24 /* Docopt.swift */,
+				OBJ_25 /* DocoptError.swift */,
+				OBJ_26 /* Either.swift */,
+				OBJ_27 /* LeafPattern.swift */,
+				OBJ_28 /* OneOrMore.swift */,
+				OBJ_29 /* Option.swift */,
+				OBJ_30 /* Optional.swift */,
+				OBJ_31 /* OptionsShortcut.swift */,
+				OBJ_32 /* Pattern.swift */,
+				OBJ_33 /* Required.swift */,
+				OBJ_34 /* String.swift */,
+				OBJ_35 /* Tokens.swift */,
+			);
+			name = "Docopt 0.6.7";
+			path = ".build/checkouts/docopt.swift--6086311741592416371/Sources";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_36 /* Logger 1.0.5 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_37 /* Logger */,
+				OBJ_45 /* Example */,
+				OBJ_46 /* Package.swift */,
 			);
 			name = "Logger 1.0.5";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_19 /* Logger */ = {
+		OBJ_37 /* Logger */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_20 /* Context.swift */,
-				OBJ_21 /* Handler.swift */,
-				OBJ_22 /* Logger.swift */,
-				OBJ_23 /* Manager.swift */,
-				OBJ_24 /* NSLogHandler.swift */,
-				OBJ_25 /* OSLogHandler.swift */,
-				OBJ_26 /* PrintHandler.swift */,
+				OBJ_38 /* Context.swift */,
+				OBJ_39 /* Handler.swift */,
+				OBJ_40 /* Logger.swift */,
+				OBJ_41 /* Manager.swift */,
+				OBJ_42 /* NSLogHandler.swift */,
+				OBJ_43 /* OSLogHandler.swift */,
+				OBJ_44 /* PrintHandler.swift */,
 			);
 			name = Logger;
 			path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Logger";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_27 /* Example */ = {
+		OBJ_45 /* Example */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -135,11 +230,12 @@
 			path = ".build/checkouts/Logger.git-7968172881489479458/Sources/Example";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_29 /* Products */ = {
+		OBJ_47 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				"Logger::Logger::Product" /* Logger.framework */,
 				"Builder::Builder::Product" /* Builder */,
+				"Docopt::Docopt::Product" /* Docopt.framework */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -150,10 +246,10 @@
 				OBJ_6 /* Package.swift */,
 				OBJ_7 /* Configs */,
 				OBJ_9 /* Sources */,
-				OBJ_15 /* Tests */,
-				OBJ_16 /* Example */,
-				OBJ_17 /* Dependencies */,
-				OBJ_29 /* Products */,
+				OBJ_16 /* Tests */,
+				OBJ_17 /* Example */,
+				OBJ_18 /* Dependencies */,
+				OBJ_47 /* Products */,
 			);
 			name = "";
 			sourceTree = "<group>";
@@ -179,15 +275,16 @@
 /* Begin PBXNativeTarget section */
 		"Builder::Builder" /* Builder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_33 /* Build configuration list for PBXNativeTarget "Builder" */;
+			buildConfigurationList = OBJ_52 /* Build configuration list for PBXNativeTarget "Builder" */;
 			buildPhases = (
-				OBJ_36 /* Sources */,
-				OBJ_41 /* Frameworks */,
+				OBJ_55 /* Sources */,
+				OBJ_61 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_43 /* PBXTargetDependency */,
+				OBJ_64 /* PBXTargetDependency */,
+				OBJ_66 /* PBXTargetDependency */,
 			);
 			name = Builder;
 			productName = Builder;
@@ -196,9 +293,9 @@
 		};
 		"Builder::SwiftPMPackageDescription" /* BuilderPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_46 /* Build configuration list for PBXNativeTarget "BuilderPackageDescription" */;
+			buildConfigurationList = OBJ_69 /* Build configuration list for PBXNativeTarget "BuilderPackageDescription" */;
 			buildPhases = (
-				OBJ_49 /* Sources */,
+				OBJ_72 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -208,12 +305,42 @@
 			productName = BuilderPackageDescription;
 			productType = "com.apple.product-type.framework";
 		};
+		"Docopt::Docopt" /* Docopt */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_74 /* Build configuration list for PBXNativeTarget "Docopt" */;
+			buildPhases = (
+				OBJ_77 /* Sources */,
+				OBJ_93 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Docopt;
+			productName = Docopt;
+			productReference = "Docopt::Docopt::Product" /* Docopt.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Docopt::SwiftPMPackageDescription" /* DocoptPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_95 /* Build configuration list for PBXNativeTarget "DocoptPackageDescription" */;
+			buildPhases = (
+				OBJ_98 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DocoptPackageDescription;
+			productName = DocoptPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
 		"Logger::Logger" /* Logger */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_51 /* Build configuration list for PBXNativeTarget "Logger" */;
+			buildConfigurationList = OBJ_100 /* Build configuration list for PBXNativeTarget "Logger" */;
 			buildPhases = (
-				OBJ_54 /* Sources */,
-				OBJ_62 /* Frameworks */,
+				OBJ_103 /* Sources */,
+				OBJ_111 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -226,9 +353,9 @@
 		};
 		"Logger::SwiftPMPackageDescription" /* LoggerPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_64 /* Build configuration list for PBXNativeTarget "LoggerPackageDescription" */;
+			buildConfigurationList = OBJ_113 /* Build configuration list for PBXNativeTarget "LoggerPackageDescription" */;
 			buildPhases = (
-				OBJ_67 /* Sources */,
+				OBJ_116 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -254,72 +381,191 @@
 				en,
 			);
 			mainGroup = OBJ_5 /*  */;
-			productRefGroup = OBJ_29 /* Products */;
+			productRefGroup = OBJ_47 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				"Builder::Builder" /* Builder */,
 				"Builder::SwiftPMPackageDescription" /* BuilderPackageDescription */,
+				"Docopt::Docopt" /* Docopt */,
+				"Docopt::SwiftPMPackageDescription" /* DocoptPackageDescription */,
 				"Logger::Logger" /* Logger */,
 				"Logger::SwiftPMPackageDescription" /* LoggerPackageDescription */,
+				"Builder::builder::ProductTarget" /* builder */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		OBJ_36 /* Sources */ = {
+		OBJ_103 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				229E1A0520501C9C00B07600 /* Arguments.swift in Sources */,
-				OBJ_37 /* Builder.swift in Sources */,
-				OBJ_38 /* Configuration.swift in Sources */,
-				OBJ_39 /* Failure.swift in Sources */,
-				OBJ_40 /* main.swift in Sources */,
+				OBJ_104 /* Context.swift in Sources */,
+				OBJ_105 /* Handler.swift in Sources */,
+				OBJ_106 /* Logger.swift in Sources */,
+				OBJ_107 /* Manager.swift in Sources */,
+				OBJ_108 /* NSLogHandler.swift in Sources */,
+				OBJ_109 /* OSLogHandler.swift in Sources */,
+				OBJ_110 /* PrintHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_49 /* Sources */ = {
+		OBJ_116 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_50 /* Package.swift in Sources */,
+				OBJ_117 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_54 /* Sources */ = {
+		OBJ_55 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_55 /* Context.swift in Sources */,
-				OBJ_56 /* Handler.swift in Sources */,
-				OBJ_57 /* Logger.swift in Sources */,
-				OBJ_58 /* Manager.swift in Sources */,
-				OBJ_59 /* NSLogHandler.swift in Sources */,
-				OBJ_60 /* OSLogHandler.swift in Sources */,
-				OBJ_61 /* PrintHandler.swift in Sources */,
+				OBJ_56 /* Arguments.swift in Sources */,
+				OBJ_57 /* Builder.swift in Sources */,
+				OBJ_58 /* Configuration.swift in Sources */,
+				OBJ_59 /* Failure.swift in Sources */,
+				OBJ_60 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_67 /* Sources */ = {
+		OBJ_72 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_68 /* Package.swift in Sources */,
+				OBJ_73 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_77 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_78 /* Argument.swift in Sources */,
+				OBJ_79 /* BranchPattern.swift in Sources */,
+				OBJ_80 /* Command.swift in Sources */,
+				OBJ_81 /* Docopt.swift in Sources */,
+				OBJ_82 /* DocoptError.swift in Sources */,
+				OBJ_83 /* Either.swift in Sources */,
+				OBJ_84 /* LeafPattern.swift in Sources */,
+				OBJ_85 /* OneOrMore.swift in Sources */,
+				OBJ_86 /* Option.swift in Sources */,
+				OBJ_87 /* Optional.swift in Sources */,
+				OBJ_88 /* OptionsShortcut.swift in Sources */,
+				OBJ_89 /* Pattern.swift in Sources */,
+				OBJ_90 /* Required.swift in Sources */,
+				OBJ_91 /* String.swift in Sources */,
+				OBJ_92 /* Tokens.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_98 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_99 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_43 /* PBXTargetDependency */ = {
+		OBJ_122 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Builder::Builder" /* Builder */;
+			targetProxy = 229E1A0C20503C2100B07600 /* PBXContainerItemProxy */;
+		};
+		OBJ_64 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Logger::Logger" /* Logger */;
-			targetProxy = 229E1A0320501C6800B07600 /* PBXContainerItemProxy */;
+			targetProxy = 229E1A0A20503C2100B07600 /* PBXContainerItemProxy */;
+		};
+		OBJ_66 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Docopt::Docopt" /* Docopt */;
+			targetProxy = 229E1A0B20503C2100B07600 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		OBJ_101 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Logger_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Logger;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Logger;
+			};
+			name = Debug;
+		};
+		OBJ_102 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Logger_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Logger;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Logger;
+			};
+			name = Release;
+		};
+		OBJ_114 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_115 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Volumes/caconym/Applications/Xcode93b2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_120 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_121 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -342,46 +588,6 @@
 			};
 			name = Debug;
 		};
-		OBJ_34 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Builder.xcodeproj/Builder_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
-				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = Builder;
-			};
-			name = Debug;
-		};
-		OBJ_35 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Builder.xcodeproj/Builder_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
-				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = Builder;
-			};
-			name = Release;
-		};
 		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -402,7 +608,47 @@
 			};
 			name = Release;
 		};
-		OBJ_47 /* Debug */ = {
+		OBJ_53 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Builder_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Builder;
+			};
+			name = Debug;
+		};
+		OBJ_54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Builder.xcodeproj/Builder_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Builder;
+			};
+			name = Release;
+		};
+		OBJ_70 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -411,7 +657,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_48 /* Release */ = {
+		OBJ_71 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -420,7 +666,7 @@
 			};
 			name = Release;
 		};
-		OBJ_52 /* Debug */ = {
+		OBJ_75 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
 			buildSettings = {
@@ -430,20 +676,20 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Builder.xcodeproj/Logger_Info.plist;
+				INFOPLIST_FILE = Builder.xcodeproj/Docopt_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = Logger;
+				PRODUCT_BUNDLE_IDENTIFIER = Docopt;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
-				TARGET_NAME = Logger;
+				TARGET_NAME = Docopt;
 			};
 			name = Debug;
 		};
-		OBJ_53 /* Release */ = {
+		OBJ_76 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = OBJ_8 /* Builder.xcconfig */;
 			buildSettings = {
@@ -453,20 +699,20 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Builder.xcodeproj/Logger_Info.plist;
+				INFOPLIST_FILE = Builder.xcodeproj/Docopt_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = Logger;
+				PRODUCT_BUNDLE_IDENTIFIER = Docopt;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
-				TARGET_NAME = Logger;
+				TARGET_NAME = Docopt;
 			};
 			name = Release;
 		};
-		OBJ_65 /* Debug */ = {
+		OBJ_96 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -475,7 +721,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_66 /* Release */ = {
+		OBJ_97 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -487,6 +733,33 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		OBJ_100 /* Build configuration list for PBXNativeTarget "Logger" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_101 /* Debug */,
+				OBJ_102 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_113 /* Build configuration list for PBXNativeTarget "LoggerPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_114 /* Debug */,
+				OBJ_115 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_119 /* Build configuration list for PBXAggregateTarget "builder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_120 /* Debug */,
+				OBJ_121 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		OBJ_2 /* Build configuration list for PBXProject "Builder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -496,38 +769,38 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_33 /* Build configuration list for PBXNativeTarget "Builder" */ = {
+		OBJ_52 /* Build configuration list for PBXNativeTarget "Builder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_34 /* Debug */,
-				OBJ_35 /* Release */,
+				OBJ_53 /* Debug */,
+				OBJ_54 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_46 /* Build configuration list for PBXNativeTarget "BuilderPackageDescription" */ = {
+		OBJ_69 /* Build configuration list for PBXNativeTarget "BuilderPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_47 /* Debug */,
-				OBJ_48 /* Release */,
+				OBJ_70 /* Debug */,
+				OBJ_71 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_51 /* Build configuration list for PBXNativeTarget "Logger" */ = {
+		OBJ_74 /* Build configuration list for PBXNativeTarget "Docopt" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_52 /* Debug */,
-				OBJ_53 /* Release */,
+				OBJ_75 /* Debug */,
+				OBJ_76 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_64 /* Build configuration list for PBXNativeTarget "LoggerPackageDescription" */ = {
+		OBJ_95 /* Build configuration list for PBXNativeTarget "DocoptPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_65 /* Debug */,
-				OBJ_66 /* Release */,
+				OBJ_96 /* Debug */,
+				OBJ_97 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Builder.xcodeproj/xcshareddata/xcschemes/Builder-Package.xcscheme
+++ b/Builder.xcodeproj/xcshareddata/xcschemes/Builder-Package.xcscheme
@@ -1,32 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion = "9999" version = "1.3">
-  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "Logger"
-          ReferencedContainer = "container:Builder.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'$(TARGET_NAME)'"
-          BlueprintName = "Builder"
-          ReferencedContainer = "container:Builder.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction
-    buildConfiguration = "Debug"
-    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-    shouldUseLaunchSchemeArgsEnv = "YES"
-    codeCoverageEnabled = "NO">
-    <Testables>
-    </Testables>
-  </TestAction>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Logger::Logger"
+               BuildableName = "Logger.framework"
+               BlueprintName = "Logger"
+               ReferencedContainer = "container:Builder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Builder::Builder"
+               BuildableName = "Builder"
+               BlueprintName = "Builder"
+               ReferencedContainer = "container:Builder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Logger::Logger"
+            BuildableName = "Logger.framework"
+            BlueprintName = "Logger"
+            ReferencedContainer = "container:Builder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/Builder.xcodeproj/xcshareddata/xcschemes/Builder-Package.xcscheme
+++ b/Builder.xcodeproj/xcshareddata/xcschemes/Builder-Package.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Logger::Logger"
-               BuildableName = "Logger.framework"
-               BlueprintName = "Logger"
+               BlueprintIdentifier = "Docopt::Docopt"
+               BuildableName = "Docopt.framework"
+               BlueprintName = "Docopt"
                ReferencedContainer = "container:Builder.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -31,6 +31,20 @@
                BlueprintIdentifier = "Builder::Builder"
                BuildableName = "Builder"
                BlueprintName = "Builder"
+               ReferencedContainer = "container:Builder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Logger::Logger"
+               BuildableName = "Logger.framework"
+               BlueprintName = "Logger"
                ReferencedContainer = "container:Builder.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -59,9 +73,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "Logger::Logger"
-            BuildableName = "Logger.framework"
-            BlueprintName = "Logger"
+            BlueprintIdentifier = "Docopt::Docopt"
+            BuildableName = "Docopt.framework"
+            BlueprintName = "Docopt"
             ReferencedContainer = "container:Builder.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Builder.xcodeproj/xcshareddata/xcschemes/Builder-Package.xcscheme
+++ b/Builder.xcodeproj/xcshareddata/xcschemes/Builder-Package.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Logger::Logger"
+               BuildableName = "Logger.framework"
+               BlueprintName = "Logger"
+               ReferencedContainer = "container:Builder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "Docopt::Docopt"
                BuildableName = "Docopt.framework"
                BlueprintName = "Docopt"
@@ -31,20 +45,6 @@
                BlueprintIdentifier = "Builder::Builder"
                BuildableName = "Builder"
                BlueprintName = "Builder"
-               ReferencedContainer = "container:Builder.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Logger::Logger"
-               BuildableName = "Logger.framework"
-               BlueprintName = "Logger"
                ReferencedContainer = "container:Builder.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -73,9 +73,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "Docopt::Docopt"
-            BuildableName = "Docopt.framework"
-            BlueprintName = "Docopt"
+            BlueprintIdentifier = "Logger::Logger"
+            BuildableName = "Logger.framework"
+            BlueprintName = "Logger"
             ReferencedContainer = "container:Builder.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/elegantchaos/docopt.swift",
         "state": {
           "branch": null,
-          "revision": "0425bb915e477ce9dbc9733ee06e519bf3b59840",
-          "version": "0.6.7"
+          "revision": "66f9a7d64e6542427a1e4eed3d8ad5ace262cf11",
+          "version": "0.6.8"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "Logger",
-        "repositoryURL": "https://github.com/elegantchaos/Logger.git",
+        "repositoryURL": "https://github.com/elegantchaos/Logger",
         "state": {
           "branch": null,
-          "revision": "d0d472ed70c4ed3cd964efa773c26e006edb17a0",
-          "version": "1.0.5"
+          "revision": "a91193074ab3bc125fd3c7dfb9338d8d79bab98f",
+          "version": "1.0.6"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Docopt",
+        "repositoryURL": "https://github.com/elegantchaos/docopt.swift",
+        "state": {
+          "branch": null,
+          "revision": "0425bb915e477ce9dbc9733ee06e519bf3b59840",
+          "version": "0.6.7"
+        }
+      },
+      {
         "package": "Logger",
         "repositoryURL": "https://github.com/elegantchaos/Logger.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
       .executable(name: "Builder", targets: ["Builder"])
     ],
     dependencies: [
-        .package(url: "https://github.com/elegantchaos/Logger", from: "1.0.5"),
+        .package(url: "https://github.com/elegantchaos/Logger", from: "1.0.6"),
         .package(url: "https://github.com/elegantchaos/docopt.swift", from: "0.6.7"),
         ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -5,15 +5,16 @@ import PackageDescription
 
 let package = Package(
     name: "Builder",
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/elegantchaos/Logger.git", from: "1.0.5"),
+    products: [
+      .executable(name: "Builder", targets: ["Builder"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/elegantchaos/Logger", from: "1.0.5"),
+        .package(url: "https://github.com/elegantchaos/docopt.swift", from: "0.6.7"),
+        ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Builder",
-            dependencies: ["Logger"]),
+            dependencies: ["Docopt", "Logger"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/elegantchaos/Logger", from: "1.0.6"),
-        .package(url: "https://github.com/elegantchaos/docopt.swift", from: "0.6.7"),
+        .package(url: "https://github.com/elegantchaos/docopt.swift", from: "0.6.8"),
         ],
     targets: [
         .target(

--- a/Sources/Builder/Arguments.swift
+++ b/Sources/Builder/Arguments.swift
@@ -1,0 +1,66 @@
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// Created by Sam Deane, 28/02/2018.
+// All code (c) 2018 - present day, Elegant Chaos Limited.
+// For licensing terms, see http://elegantchaos.com/license/liberal/.
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+
+struct Arguments {
+  struct Option {
+    let name : String
+    let consume : Bool
+    let hasValue : Bool
+
+    init(_ name : String, consume : Bool = false, hasValue : Bool = false) {
+      self.name = name
+      self.consume = consume
+      self.hasValue = hasValue
+    }
+  }
+
+  let application : String
+  let options : [String:String]
+  var unused : [String] = []
+  init(options recognisedOptions : [Option]) {
+
+    var options : [String:String] = [:]
+    var valueOwner : Option?
+    for argument in CommandLine.arguments {
+      if let option = valueOwner {
+        options[option.name] = argument
+        if !option.consume {
+          unused.append(argument)
+        }
+      } else if argument.starts(with:"-") {
+        for option in recognisedOptions {
+          if argument == option.name {
+            if option.hasValue {
+              valueOwner = option
+            } else {
+              options[argument] = "true"
+            }
+            if !option.consume {
+              unused.append(argument)
+            }
+          }
+        }
+      } else if argument != "" {
+        unused.append(argument)
+      }
+    }
+
+    self.options = options
+    self.application = unused[0]
+    unused.removeFirst()
+  }
+
+  mutating func pop(`default`: String ) -> String {
+    guard unused.count > 0 else {
+      return `default`
+    }
+
+    let value = unused[0]
+    unused.removeFirst()
+    return value
+  }
+}

--- a/Sources/Builder/Arguments.swift
+++ b/Sources/Builder/Arguments.swift
@@ -6,90 +6,39 @@
 
 /**
  Rudimentary argument parsing.
- 
+
  For a real implementation we'd be better off with something like docopt here.
  */
 
+import Docopt
+
 struct Arguments {
-    
-    internal class Option {
-        let name : String
-        let consume : Bool
-        let hasValue : Bool
-        let `default` : String?
-        
-        init(_ name : String, consume : Bool, hasValue : Bool, `default` : String?) {
-            self.name = name
-            self.consume = consume
-            self.hasValue = hasValue
-            self.default = `default`
-        }
-    }
-    
-    internal class BoolOption : Option {
-        init(_ name : String, consume : Bool = true) {
-            super.init(name, consume: consume, hasValue: false, default: "false")
-        }
-    }
-    
-    internal class ValueOption : Option {
-        init(_ name : String, consume : Bool = true, `default` : String? = nil) {
-            super.init(name, consume: consume, hasValue: true, default: `default`)
-        }
-    }
-    
-    private let options : [String:String]
-    let application : String
-    var unused : [String] = []
+    let program : String
+    let parsed : [String:Any]
     
     /**
      Parse the command line arguments.
-     
+
      Any recognised options are pulled out into the options dictionary.
      Other arguments end up in the unused array (so that they can be passed on to a sub-process, for example).
      */
-    
-    init(options recognisedOptions : [Option]) {
-        
-        var options : [String:String] = [:]
-        for option in recognisedOptions {
-            if option.default != nil {
-                options[option.name] = option.default
-            }
-        }
-        var valueOwner : Option?
+
+    init(documentation : String) {
+        var args : [String] = []
+        var dropNext = false
         for argument in CommandLine.arguments {
-            if let option = valueOwner {
-                options[option.name] = argument
-                if !option.consume {
-                    unused.append(option.name)
-                    unused.append(argument)
-                }
-                valueOwner = nil
-            } else if argument.starts(with:"-") {
-                var matched = false
-                for option in recognisedOptions {
-                    if argument == option.name {
-                        matched = true
-                        if option.hasValue {
-                            valueOwner = option
-                        } else {
-                            options[argument] = "true"
-                        }
-                        break
-                    }
-                }
-                if !matched {
-                    unused.append(argument)
-                }
-            } else if argument != "" {
-                unused.append(argument)
+            if (argument == "-logs") || (argument == "-logs+" || argument == "-logs-") {
+                dropNext = true
+            } else if dropNext {
+                dropNext = false
+            } else {
+                args.append(argument)
             }
         }
-        
-        self.options = options
-        self.application = unused[0]
-        self.unused.removeFirst()
+
+        self.program = args[0]
+        args.removeFirst()
+        self.parsed = Docopt.parse(doc, argv: args, help: true, version: "1.0")
     }
     
     /**
@@ -99,24 +48,28 @@ struct Arguments {
      */
     
     func option(_ name : String) throws -> String  {
-        guard let value = options[name] else {
-            throw Failure.unknownOption(name: name)
+        if let value = parsed["--\(name)"] as? String {
+            return value
         }
         
-        return value
+        if let value = parsed["-\(name)"] as? String {
+            return value
+        }
+        
+        throw Failure.unknownOption(name: name)
     }
-    
+
     /**
-     Shift a value off the front of the unused arguments, consuming it.
-    */
+     Return an argument, or a default value if it's missing.
+     It's an error to try to read an argument that wasn't passed in when
+     we were set up.
+     */
     
-    mutating func shift(`default`: String ) -> String {
-        guard unused.count > 0 else {
-            return `default`
+    func argument(_ name : String, `default` : String) -> String  {
+        if let value = parsed["<\(name)>"] as? String {
+            return value
         }
-        
-        let value = unused[0]
-        unused.removeFirst()
-        return value
+        return `default`
     }
+
 }

--- a/Sources/Builder/Arguments.swift
+++ b/Sources/Builder/Arguments.swift
@@ -1,12 +1,18 @@
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// Created by Sam Deane, 28/02/2018.
+// Created by Sam Deane, 07/03/2018.
 // All code (c) 2018 - present day, Elegant Chaos Limited.
 // For licensing terms, see http://elegantchaos.com/license/liberal/.
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+/**
+ Rudimentary argument parsing.
+ 
+ For a real implementation we'd be better off with something like docopt here.
+ */
 
 struct Arguments {
-    class Option {
+    
+    internal class Option {
         let name : String
         let consume : Bool
         let hasValue : Bool
@@ -20,21 +26,29 @@ struct Arguments {
         }
     }
     
-    class BoolOption : Option {
+    internal class BoolOption : Option {
         init(_ name : String, consume : Bool = true) {
             super.init(name, consume: consume, hasValue: false, default: "false")
         }
     }
     
-    class ValueOption : Option {
+    internal class ValueOption : Option {
         init(_ name : String, consume : Bool = true, `default` : String? = nil) {
             super.init(name, consume: consume, hasValue: true, default: `default`)
         }
     }
     
+    private let options : [String:String]
     let application : String
-    let options : [String:String]
     var unused : [String] = []
+    
+    /**
+     Parse the command line arguments.
+     
+     Any recognised options are pulled out into the options dictionary.
+     Other arguments end up in the unused array (so that they can be passed on to a sub-process, for example).
+     */
+    
     init(options recognisedOptions : [Option]) {
         
         var options : [String:String] = [:]
@@ -78,15 +92,25 @@ struct Arguments {
         self.unused.removeFirst()
     }
     
-    func option(_ name : String, `default` : String = "") -> String {
+    /**
+     Return an option, or a default value if it's missing.
+     It's an error to try to read an option that wasn't passed in when
+     we were set up.
+     */
+    
+    func option(_ name : String) throws -> String  {
         guard let value = options[name] else {
-            return `default`
+            throw Failure.unknownOption(name: name)
         }
         
         return value
     }
     
-    mutating func pop(`default`: String ) -> String {
+    /**
+     Shift a value off the front of the unused arguments, consuming it.
+    */
+    
+    mutating func shift(`default`: String ) -> String {
         guard unused.count > 0 else {
             return `default`
         }

--- a/Sources/Builder/Arguments.swift
+++ b/Sources/Builder/Arguments.swift
@@ -42,7 +42,7 @@ struct Arguments {
     }
     
     /**
-     Return an option, or a default value if it's missing.
+     Return an option.
      It's an error to try to read an option that wasn't passed in when
      we were set up.
      */
@@ -52,17 +52,11 @@ struct Arguments {
             return value
         }
         
-        if let value = parsed["-\(name)"] as? String {
-            return value
-        }
-        
         throw Failure.unknownOption(name: name)
     }
 
     /**
      Return an argument, or a default value if it's missing.
-     It's an error to try to read an argument that wasn't passed in when
-     we were set up.
      */
     
     func argument(_ name : String, `default` : String) -> String  {

--- a/Sources/Builder/Arguments.swift
+++ b/Sources/Builder/Arguments.swift
@@ -5,16 +5,17 @@
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 /**
- Rudimentary argument parsing.
-
- For a real implementation we'd be better off with something like docopt here.
+ Argument parsing.
+ Uses Docopt for the heavy lifting, but performs a bit of preliminary
+ cleanup first, and provides a simplified API to read options and arguments.
  */
 
 import Docopt
+import Logger
 
 struct Arguments {
     let program : String
-    let parsed : [String:Any]
+    private let parsed : [String:Any]
     
     /**
      Parse the command line arguments.
@@ -24,21 +25,9 @@ struct Arguments {
      */
 
     init(documentation : String) {
-        var args : [String] = []
-        var dropNext = false
-        for argument in CommandLine.arguments {
-            if (argument == "-logs") || (argument == "-logs+" || argument == "-logs-") {
-                dropNext = true
-            } else if dropNext {
-                dropNext = false
-            } else {
-                args.append(argument)
-            }
-        }
-
-        self.program = args[0]
-        args.removeFirst()
-        self.parsed = Docopt.parse(doc, argv: args, help: true, version: "1.0")
+        let filteredArguments = Manager.removeLoggingOptions(from: CommandLine.arguments)
+        self.program = filteredArguments[0]
+        self.parsed = Docopt.parse(doc, argv: Array(filteredArguments[1...]), help: true, version: "1.0")
     }
     
     /**

--- a/Sources/Builder/Arguments.swift
+++ b/Sources/Builder/Arguments.swift
@@ -6,61 +6,93 @@
 
 
 struct Arguments {
-  struct Option {
-    let name : String
-    let consume : Bool
-    let hasValue : Bool
-
-    init(_ name : String, consume : Bool = false, hasValue : Bool = false) {
-      self.name = name
-      self.consume = consume
-      self.hasValue = hasValue
-    }
-  }
-
-  let application : String
-  let options : [String:String]
-  var unused : [String] = []
-  init(options recognisedOptions : [Option]) {
-
-    var options : [String:String] = [:]
-    var valueOwner : Option?
-    for argument in CommandLine.arguments {
-      if let option = valueOwner {
-        options[option.name] = argument
-        if !option.consume {
-          unused.append(argument)
+    class Option {
+        let name : String
+        let consume : Bool
+        let hasValue : Bool
+        let `default` : String?
+        
+        init(_ name : String, consume : Bool, hasValue : Bool, `default` : String?) {
+            self.name = name
+            self.consume = consume
+            self.hasValue = hasValue
+            self.default = `default`
         }
-      } else if argument.starts(with:"-") {
+    }
+    
+    class BoolOption : Option {
+        init(_ name : String, consume : Bool = true) {
+            super.init(name, consume: consume, hasValue: false, default: "false")
+        }
+    }
+    
+    class ValueOption : Option {
+        init(_ name : String, consume : Bool = true, `default` : String? = nil) {
+            super.init(name, consume: consume, hasValue: true, default: `default`)
+        }
+    }
+    
+    let application : String
+    let options : [String:String]
+    var unused : [String] = []
+    init(options recognisedOptions : [Option]) {
+        
+        var options : [String:String] = [:]
         for option in recognisedOptions {
-          if argument == option.name {
-            if option.hasValue {
-              valueOwner = option
-            } else {
-              options[argument] = "true"
+            if option.default != nil {
+                options[option.name] = option.default
             }
-            if !option.consume {
-              unused.append(argument)
-            }
-          }
         }
-      } else if argument != "" {
-        unused.append(argument)
-      }
+        var valueOwner : Option?
+        for argument in CommandLine.arguments {
+            if let option = valueOwner {
+                options[option.name] = argument
+                if !option.consume {
+                    unused.append(option.name)
+                    unused.append(argument)
+                }
+                valueOwner = nil
+            } else if argument.starts(with:"-") {
+                var matched = false
+                for option in recognisedOptions {
+                    if argument == option.name {
+                        matched = true
+                        if option.hasValue {
+                            valueOwner = option
+                        } else {
+                            options[argument] = "true"
+                        }
+                        break
+                    }
+                }
+                if !matched {
+                    unused.append(argument)
+                }
+            } else if argument != "" {
+                unused.append(argument)
+            }
+        }
+        
+        self.options = options
+        self.application = unused[0]
+        self.unused.removeFirst()
     }
-
-    self.options = options
-    self.application = unused[0]
-    unused.removeFirst()
-  }
-
-  mutating func pop(`default`: String ) -> String {
-    guard unused.count > 0 else {
-      return `default`
+    
+    func option(_ name : String, `default` : String = "") -> String {
+        guard let value = options[name] else {
+            return `default`
+        }
+        
+        return value
     }
-
-    let value = unused[0]
-    unused.removeFirst()
-    return value
-  }
+    
+    mutating func pop(`default`: String ) -> String {
+        guard unused.count > 0 else {
+            return `default`
+        }
+        
+        let value = unused[0]
+        unused.removeFirst()
+        return value
+    }
 }

--- a/Sources/Builder/Builder.swift
+++ b/Sources/Builder/Builder.swift
@@ -5,7 +5,6 @@
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 import Foundation
-import os
 
 /**
  Builder.
@@ -27,7 +26,7 @@ class Builder {
     let configuration : String
     var environment : [String:String] = ProcessInfo.processInfo.environment
     lazy var swiftPath = findSwift()
-    
+
     init(command : String = "build", configuration : String = "debug") {
         self.command = command
         self.configuration = configuration
@@ -36,11 +35,11 @@ class Builder {
         self.environment["BUILDER_COMMAND"] = command
         self.environment["BUILDER_CONFIGURATION"] = configuration
     }
-    
+
     /**
      Return the path to the swift binary.
      */
-    
+
     func findSwift() -> String {
         let path : String
         do {
@@ -48,16 +47,16 @@ class Builder {
         } catch {
             path = "/usr/bin/swift"
         }
-        
+
         return path
     }
-    
-    
+
+
     /**
      Invoke a command and some optional arguments.
      Control is transferred to the launched process, and this function doesn't return.
      */
-    
+
     func exec(_ command : String, arguments: [String] = []) {
         let process = Process()
         process.launchPath = command
@@ -68,7 +67,7 @@ class Builder {
         exit(process.terminationStatus)
     }
 
-    
+
     /**
      Invoke a command and some optional arguments.
      On success, returns the captured output from stdout.
@@ -80,7 +79,7 @@ class Builder {
         let handle = pipe.fileHandleForReading
         let errPipe = Pipe()
         let errHandle = errPipe.fileHandleForReading
-        
+
         let process = Process()
         process.launchPath = command
         process.arguments = arguments
@@ -132,7 +131,7 @@ class Builder {
 
         return decoded
     }
-    
+
     /**
      Announce the build stage.
     */
@@ -142,18 +141,18 @@ class Builder {
         }
         environment["BUILDER_STAGE"] = stage.lowercased()
     }
-    
+
     /**
      Execute the phases associated with a given scheme.
      */
-    
+
     func execute(scheme name: String, configuration : Configuration, settings : [String]) throws {
         guard let scheme = configuration.schemes[name] else {
             throw Failure.missingScheme(name: name)
         }
-        
+
         output.log("\nScheme:\n- \(name).")
-        
+
         for phase in scheme {
             setStage(phase.name)
             let tool = phase.tool
@@ -179,7 +178,7 @@ class Builder {
             }
         }
     }
-    
+
     /**
      Perform the build.
      */
@@ -206,13 +205,13 @@ class Builder {
         let json = try run(configurePath)
         output.log("- parsing output")
         let configuration = try parse(configuration: json)
-        
+
         let settings = configuration.compilerSettings()
         environment["BUILDER_SETTINGS"] = settings.joined(separator: ",")
 
         // execute the scheme associated with the primary command we were passed (run/build/test/etc)
         try execute(scheme: command, configuration: configuration, settings: settings)
-        
+
         output.log("\nDone.\n\n")
     }
 

--- a/Sources/Builder/Builder.swift
+++ b/Sources/Builder/Builder.swift
@@ -24,13 +24,16 @@ import os
 
 class Builder {
     let command : String
+    let configuration : String
     var environment : [String:String] = ProcessInfo.processInfo.environment
     
-    init(command : String = "build") {
+    init(command : String = "build", configuration : String = "debug") {
         self.command = command
-        // TODO: flesh this out
-        self.environment["BUILDER_COMMAND"] = "build"
-        self.environment["BUILDER_CONFIGURATION"] = "debug" // TODO: read from the command line
+        self.configuration = configuration
+
+        // TODO: flesh the environment out with more useful stuff
+        self.environment["BUILDER_COMMAND"] = command
+        self.environment["BUILDER_CONFIGURATION"] = configuration
     }
     
     /**
@@ -128,15 +131,15 @@ class Builder {
             switch (tool) {
             case "test":
                 let product = phase.arguments[0]
-                let toolOutput = try swift("test", arguments: settings)
+                let toolOutput = try swift("test", arguments: ["--configuration", self.configuration] + settings)
                 output.log("- tested \(product).\n\n\(toolOutput)")
             case "run":
                 let product = phase.arguments[0]
-                let toolOutput = try swift("run", arguments: [product] + settings)
+                let toolOutput = try swift("run", arguments: [product, "--configuration", self.configuration] + settings)
                 output.log("- ran \(product).\n\n\(toolOutput)")
             case "build":
                 let product = phase.arguments[0]
-                let _ = try swift("build", arguments: ["--product", product] + settings)
+                let _ = try swift("build", arguments: ["--product", product, "--configuration", self.configuration] + settings)
                 output.log("- built \(product).")
             case "scheme":
                 let scheme = phase.arguments[0]

--- a/Sources/Builder/Builder.swift
+++ b/Sources/Builder/Builder.swift
@@ -121,7 +121,7 @@ class Builder {
     
     func execute(scheme name: String, configuration : Configuration, settings : [String]) throws {
         guard let scheme = configuration.schemes[name] else {
-            throw Failure.missingScheme(scheme: name)
+            throw Failure.missingScheme(name: name)
         }
         
         output.log("Scheme: \(command)")

--- a/Sources/Builder/Failure.swift
+++ b/Sources/Builder/Failure.swift
@@ -11,6 +11,7 @@
 enum Failure : Error {
     case failed(output : String?, error : String?)
     case decodingFailed
-    case missingScheme(scheme : String)
+    case missingScheme(name : String)
+    case unknownOption(name : String)
 }
 

--- a/Sources/Builder/main.swift
+++ b/Sources/Builder/main.swift
@@ -6,24 +6,29 @@
 
 import Logger
 
-let args = CommandLine.arguments.filter { (arg) -> Bool in
-    return !(arg == "" || arg.starts(with:"-"))
-}
-var command = args.count > 1 ? args[1] : "build"
-
 let output = Logger.stdout
 let verbose = Logger("com.elegantchaos.builder.verbose", handlers:[PrintHandler()])
 
-do {
-    let builder = Builder(command: command)
-    try builder.build(configurationTarget: "Configure")
-} catch Failure.decodingFailed {
-    output.log("Couldn't decode JSON")
-} catch Failure.failed(let stdout, let stderr) {
-    output.log(stdout ?? "Failure:")
-    output.log(stderr ?? "")
-} catch Failure.missingScheme(let scheme) {
-    output.log("Couldn't find scheme: \(scheme)")
-} catch {
-    output.log("Failed: \(error)")
-}
+let options =     [
+    Arguments.ValueOption("-logs"),
+    Arguments.ValueOption("--configuration", default: "debug"),
+    Arguments.BoolOption("--testBool")
+]
+
+var args = Arguments(options: options)
+let command = args.pop(default: "build")
+
+ do {
+    let builder = Builder(command: command, configuration: args.option("--configuration"))
+     try builder.build(configurationTarget: "Configure")
+ } catch Failure.decodingFailed {
+     output.log("Couldn't decode JSON")
+ } catch Failure.failed(let stdout, let stderr) {
+     output.log(stdout ?? "Failure:")
+     output.log(stderr ?? "")
+ } catch Failure.missingScheme(let scheme) {
+     output.log("Couldn't find scheme: \(scheme)")
+ } catch {
+     output.log("Failed: \(error)")
+ }
+

--- a/Sources/Builder/main.swift
+++ b/Sources/Builder/main.swift
@@ -6,7 +6,7 @@
 
 import Logger
 
-let doc : String = """
+let doc = """
 Build, test, and run SwiftPM packages.
 
 Usage:
@@ -41,7 +41,7 @@ let command = args.argument("command", default: "build")
 do {
     let configuration = try args.option("configuration")
     let builder = Builder(command: command, configuration: configuration)
-    try builder.build(configurationTarget: "Configure")
+    try builder.execute(configurationTarget: "Configure")
 
 } catch Failure.decodingFailed {
     output.log("Couldn't decode JSON")

--- a/Sources/Builder/main.swift
+++ b/Sources/Builder/main.swift
@@ -6,20 +6,40 @@
 
 import Logger
 
+let doc : String = """
+Build, test, and run SwiftPM packages.
+
+Usage:
+    builder [<command>] [--configuration <config>]
+    builder (-h | --help)
+
+Arguments:
+    <command>                       The command to execute [default: build].
+
+
+Options:
+    -h, --help                      Show this text.
+    -c, --configuration <config>    The configuration to build [default: debug].
+    -logs <logs>                    Specify all log channels to enable.
+    -logs+ <logs>                   Specify additional log channels to enable.
+    -logs- <logs>                   Specify log channels to disable.
+
+Examples:
+    builder build --configuration release
+    builder test
+
+
+
+"""
+
 let output = Logger.stdout
 let verbose = Logger("com.elegantchaos.builder.verbose", handlers:[PrintHandler()])
 
-let options =     [
-    Arguments.ValueOption("-logs"),
-    Arguments.ValueOption("--configuration", default: "debug"),
-    Arguments.BoolOption("--testBool")
-]
-
-var args = Arguments(options: options)
-let command = args.shift(default: "build")
+var args = Arguments(documentation: doc)
+let command = args.argument("command", default: "build")
 
 do {
-    let configuration = try args.option("--configuration")
+    let configuration = try args.option("configuration")
     let builder = Builder(command: command, configuration: configuration)
     try builder.build(configurationTarget: "Configure")
 
@@ -39,4 +59,5 @@ do {
 } catch {
     output.log("Failed: \(error)")
 }
+
 

--- a/Sources/Builder/main.swift
+++ b/Sources/Builder/main.swift
@@ -16,19 +16,27 @@ let options =     [
 ]
 
 var args = Arguments(options: options)
-let command = args.pop(default: "build")
+let command = args.shift(default: "build")
 
- do {
-    let builder = Builder(command: command, configuration: args.option("--configuration"))
-     try builder.build(configurationTarget: "Configure")
- } catch Failure.decodingFailed {
-     output.log("Couldn't decode JSON")
- } catch Failure.failed(let stdout, let stderr) {
-     output.log(stdout ?? "Failure:")
-     output.log(stderr ?? "")
- } catch Failure.missingScheme(let scheme) {
-     output.log("Couldn't find scheme: \(scheme)")
- } catch {
-     output.log("Failed: \(error)")
- }
+do {
+    let configuration = try args.option("--configuration")
+    let builder = Builder(command: command, configuration: configuration)
+    try builder.build(configurationTarget: "Configure")
+
+} catch Failure.decodingFailed {
+    output.log("Couldn't decode JSON")
+
+} catch Failure.failed(let stdout, let stderr) {
+    output.log(stdout ?? "Failure:")
+    output.log(stderr ?? "")
+
+} catch Failure.missingScheme(let name) {
+    output.log("Couldn't find scheme: \(name)")
+
+} catch Failure.unknownOption(let name) {
+    output.log("Tried to read unknown option: \(name)")
+
+} catch {
+    output.log("Failed: \(error)")
+}
 

--- a/Sources/Builder/main.swift
+++ b/Sources/Builder/main.swift
@@ -10,7 +10,7 @@ let doc = """
 Build, test, and run SwiftPM packages.
 
 Usage:
-    builder [<command>] [--configuration <config>]
+    builder [<command>] [--configuration <config>] [--] [<other>...]
     builder (-h | --help)
 
 Arguments:


### PR DESCRIPTION
Resolves #14.

If we fail to find a Configure target, we drop back to just calling on to `swift` with the arguments we were given.

Resolves #16.

Now using `which` as a way of finding swift. Probably a silly way to do it, but better than hard-coding the path.

Resolves #5.

If the user passes `--configuration <c>`, we pass it on to `swift`.
