### PR TITLE
Refactor building

### DIFF
--- a/Sources/Builder/Builder.swift
+++ b/Sources/Builder/Builder.swift
@@ -287,11 +287,7 @@ public class Builder {
 
         level += 1
         if level > 1 {
-            indent = ""
-            for n in 2..<level {
-                indent += "  "
-            }
-            indent += "- "
+            indent = "- ".padding(toLength: (level - 1) * 2, withPad: " ", startingAt: 0)
         }
 
         verbose.log("\(indent)Action: \(name).")

--- a/Sources/Builder/BuilderActions.swift
+++ b/Sources/Builder/BuilderActions.swift
@@ -1,0 +1,97 @@
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// Created by Sam Deane, 13/07/2018.
+// All code (c) 2018 - present day, Elegant Chaos Limited.
+// For licensing terms, see http://elegantchaos.com/license/liberal/.
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+import Foundation
+
+class BuilderAction {
+    let engine: Builder
+
+    init(engine: Builder) {
+        self.engine = engine
+    }
+
+    func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+    }
+}
+
+class BuildAction: BuilderAction {
+    override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+        let product = phase.arguments[0]
+        let _ = try engine.swift("build", arguments: ["--product", product, "--configuration", engine.configuration] + settings)
+        engine.output.log("- built \(product).")
+    }
+}
+
+class RunAction: BuilderAction {
+    override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+        var args: [String] = []
+        var product = "default product"
+        args.append(contentsOf: ["--configuration", engine.configuration])
+        args.append(contentsOf: settings)
+        if phase.arguments.count > 0 {
+            product = phase.arguments[0]
+            args.append(product)
+        }
+        args.append(contentsOf: phase.arguments)
+        let toolOutput = try engine.swift("run", arguments: args)
+        engine.output.log("- ran \(product).\n\n\(toolOutput)")
+    }
+}
+
+class MetadataAction: BuilderAction {
+    override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+        let product = phase.arguments[0]
+        writeMetadata(product: product)
+    }
+
+    func writeMetadata(product: String) {
+        let environment = engine.environment
+        let build = environment["BUILDER_BUILD"] ?? "unknown"
+        let commit = environment["BUILDER_GIT_COMMIT"] ?? "unknown"
+        let tags = environment["BUILDER_GIT_TAGS"] ?? ""
+        let version = environment["BUILDER_VERSION"] ?? "0.0.0"
+        let metadata = """
+        struct Metadata {
+            let version: String
+            let build: String
+            let tags: String
+            let commit: String
+        }
+
+        let \(product)Metadata = Metadata(version: "\(version)", build: "\(build)", tags: "\(tags)", commit: "\(commit)")
+        """
+        let metadataURL = URL(fileURLWithPath: "./Sources").appendingPathComponent(product).appendingPathComponent("Metadata.swift")
+        do {
+            try metadata.write(to: metadataURL, atomically: true, encoding: String.Encoding.utf8)
+        } catch {
+            print(metadataURL)
+            print(error)
+        }
+    }
+}
+
+class TestAction: BuilderAction {
+    override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+        let product = phase.arguments[0]
+        let toolOutput = try engine.swift("test", arguments: ["--configuration", engine.configuration] + settings)
+        engine.output.log("- tested \(product).\n\n\(toolOutput)")
+    }
+}
+
+class ActionAction: BuilderAction {
+    override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+        let action = phase.arguments[0]
+        try engine.execute(action: action, configuration: configuration, settings: settings)
+    }
+}
+
+class DefaultAction: BuilderAction {
+    override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
+        let command = phase.command
+        let toolOutput = try engine.swift("run", arguments: settings + [command] + phase.arguments)
+        engine.output.log("- ran \(command): \(toolOutput)")
+    }
+}

--- a/Sources/Builder/BuilderActions.swift
+++ b/Sources/Builder/BuilderActions.swift
@@ -19,25 +19,33 @@ class BuilderAction {
 
 class BuildAction: BuilderAction {
     override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
-        let product = phase.arguments[0]
-        let _ = try engine.swift("build", arguments: ["--product", product, "--configuration", engine.configuration] + settings)
-        engine.output.log("- built \(product).")
+        let (product, args) = arguments(for: phase, configuration: configuration, settings: settings)
+        let _ = try engine.swift("build", arguments: args)
+        engine.output.log("\(engine.indent)Built \(product).")
+    }
+
+    func arguments(for phase: Phase, configuration : Configuration, settings: [String]) -> (String, [String]) {
+        var args: [String] = []
+        args.append(contentsOf: ["--configuration", engine.configuration])
+        var product = "default product"
+        if phase.arguments.count > 0 {
+            product = phase.arguments[0]
+            args.append("--product")
+            args.append(product)
+        }
+        args.append(contentsOf: settings)
+        return (product, args)
     }
 }
 
-class RunAction: BuilderAction {
+class RunAction: BuildAction {
     override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
-        var args: [String] = []
-        var product = "default product"
-        args.append(contentsOf: ["--configuration", engine.configuration])
-        args.append(contentsOf: settings)
-        if phase.arguments.count > 0 {
-            product = phase.arguments[0]
-            args.append(product)
-        }
-        args.append(contentsOf: phase.arguments)
-        let toolOutput = try engine.swift("run", arguments: args)
-        engine.output.log("- ran \(product).\n\n\(toolOutput)")
+        var (product, args) = arguments(for: phase, configuration: configuration, settings: settings)
+        args.append("--show-bin-path")
+        let path = try engine.swift("build", arguments: args).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        let url = URL(fileURLWithPath: path).appendingPathComponent(product)
+        let toolOutput = try engine.run(url.path, arguments: Array(phase.arguments.dropFirst()))
+        engine.output.log("\(engine.indent)Ran \(product).\n\n\(toolOutput)")
     }
 }
 
@@ -77,7 +85,7 @@ class TestAction: BuilderAction {
     override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
         let product = phase.arguments[0]
         let toolOutput = try engine.swift("test", arguments: ["--configuration", engine.configuration] + settings)
-        engine.output.log("- tested \(product).\n\n\(toolOutput)")
+        engine.output.log("\(engine.indent)- tested \(product).\n\n\(toolOutput)")
     }
 }
 
@@ -92,6 +100,6 @@ class DefaultAction: BuilderAction {
     override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
         let command = phase.command
         let toolOutput = try engine.swift("run", arguments: settings + [command] + phase.arguments)
-        engine.output.log("- ran \(command): \(toolOutput)")
+        engine.verbose.log("\(engine.indent)- ran \(command): \(toolOutput)")
     }
 }


### PR DESCRIPTION
Split built-in build actions into separate classes.
Cleaned up the output a lot to make it more compact.