### PR TITLE
Added Info.plist support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Docopt",
-        "repositoryURL": "https://github.com/elegantchaos/docopt.swift",
+        "repositoryURL": "https://github.com/elegantchaos/docopt.swift.git",
         "state": {
           "branch": null,
           "revision": "fa71fca4b4e7411c70a21ef89256cd04a64c6dda",
@@ -12,11 +12,11 @@
       },
       {
         "package": "Logger",
-        "repositoryURL": "https://github.com/elegantchaos/Logger",
+        "repositoryURL": "https://github.com/elegantchaos/Logger.git",
         "state": {
           "branch": null,
-          "revision": "65d89667f72e480aba8ed37c3d874a0c5349a005",
-          "version": "1.3.6"
+          "revision": "c101ca48876adabeb25848f5fe0efba748c24d73",
+          "version": "1.3.7"
         }
       }
     ]

--- a/Sources/Builder/Builder.swift
+++ b/Sources/Builder/Builder.swift
@@ -36,7 +36,8 @@ public class Builder {
     lazy var swiftPath = findSwift()
     lazy var xcrunPath = findXCRun()
     lazy var gitPath = findGit()
-
+    lazy var buildPath = findBuildPath()
+    
     public init(command: String = "build", configuration: String = "debug", platform: String = Platform.currentPlatform(), output: Logger, verbose: Logger, arguments: [String]) {
         self.command = command
         self.configuration = configuration
@@ -116,7 +117,14 @@ public class Builder {
 
     }
 
-
+    func findBuildPath() -> String {
+        return ".build/\(configuration)"
+    }
+    
+    func linkablePlistPath(for product: String) -> String {
+        return "\(buildPath)/\(product)_info.plist"
+    }
+    
     /**
      Return the path to the swift binary.
      */

--- a/Sources/Builder/BuilderActions.swift
+++ b/Sources/Builder/BuilderActions.swift
@@ -33,6 +33,13 @@ class BuildAction: BuilderAction {
             args.append("--product")
             args.append(product)
         }
+        
+        // if something has placed an info plist file into the build products folder, link it in
+        let infoPath = ".build/\(engine.configuration)/\(product)_info.plist"
+        if FileManager.default.fileExists(atPath: infoPath) {
+            args.append(contentsOf: ["-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__Info_plist", "-Xlinker", infoPath])
+        }
+        
         args.append(contentsOf: settings)
         return (product, args)
     }


### PR DESCRIPTION
The build command now looks for a special Info.plist file  with the name `<product>_Info.plst>` in the build products folder. If it finds it, it links it into the TEXT segment.

This file acts as a place that any tool can write keys into, for inclusion in the executable's Info.plist.

The metadata command now writes the metadata into the special plist file.
It also looks for a file `Sources/<product>/Info.plist`. If it finds it, it also merges the contents of it into the special plist file. You can use this feature to define other plist keys statically, which will be included automatically.
