### PR TITLE
More plist fixes

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Builder/Builder.swift
+++ b/Sources/Builder/Builder.swift
@@ -183,7 +183,7 @@ public class Builder {
         process.environment = self.environment
         process.launch()
         process.waitUntilExit()
-        exit(process.terminationStatus)
+        Builder.exit(code: process.terminationStatus)
     }
 
 
@@ -359,6 +359,15 @@ public class Builder {
         // execute the action associated with the primary command we were passed (run/build/test/etc)
         try execute(action: command, configuration: configuration, settings: mapped)
 
-        output.log("\nDone.\n\n")
+        output.log("Done.\n\n")
+    }
+
+    public class func exit(code: Int) {
+        exit(code: Int32(code))
+    }
+
+    public class func exit(code: Int32) {
+        Logger.defaultManager.flush()
+        Foundation.exit(Int32(code))
     }
 }

--- a/Sources/Builder/BuilderActions.swift
+++ b/Sources/Builder/BuilderActions.swift
@@ -73,16 +73,16 @@ class RunAction: BuilderAction {
 class MetadataAction: BuilderAction {
     override func run(phase: Phase, configuration : Configuration, settings: [String]) throws {
         let product = phase.arguments[0]
-        let plist = phase.arguments.count > 1 ? phase.arguments[1] : "Info.plist"
-        writeMetadata(product: product, plistName: plist)
+        let plist = phase.arguments.count > 1 ? phase.arguments[1] : "Sources/\(product)/Info.plist"
+        writeMetadata(product: product, plistPath: plist)
     }
 
-    func writeMetadata(product: String, plistName: String) {
+    func writeMetadata(product: String, plistPath: String) {
         let environment = engine.environment
         var info: [String:Any] = [:]
 
-        let sourcePath = "./Sources/\(product)/\(plistName)"
-        if let data = try? Data(contentsOf: URL(fileURLWithPath: sourcePath)) {
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        if let data = try? Data(contentsOf: cwd.appendingPathComponent(plistPath)) {
             if let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) {
                 if let existing = plist as? [String:Any] {
                     info.merge(existing, uniquingKeysWith: { (key1, key2) in return key1 })

--- a/Sources/Builder/Failure.swift
+++ b/Sources/Builder/Failure.swift
@@ -40,19 +40,18 @@ public enum Failure : Error {
     Output a log message describing the failure, then exit.
     */
 
-    public func logAndExit(_ output: Logger) {
+    public func logAndExit(_ channel: Channel) {
         switch self {
             case .decodingFailed:
-                output.log("Couldn't decode JSON")
+                channel.log("Couldn't decode JSON")
             case .failed(let stdout, let stderr):
-                output.log(stdout ?? "Failure:")
-                output.log(stderr ?? "")
+                channel.log(stdout ?? "Failure:")
+                channel.log(stderr ?? "")
             case .missingScheme(let name):
-                output.log("Couldn't find scheme: \(name)")
+                channel.log("Couldn't find scheme: \(name)")
             case .unknownOption(let name):
-                output.log("Tried to read unknown option: \(name)")
+                channel.log("Tried to read unknown option: \(name)")
         }
-        Logger.defaultManager.flush()
-        exit(self.exitCode)
+        Builder.exit(code: self.exitCode)
     }
 }

--- a/Sources/Builder/Failure.swift
+++ b/Sources/Builder/Failure.swift
@@ -52,6 +52,7 @@ public enum Failure : Error {
             case .unknownOption(let name):
                 output.log("Tried to read unknown option: \(name)")
         }
+        Logger.defaultManager.flush()
         exit(self.exitCode)
     }
 }

--- a/Sources/BuilderCommand/main.swift
+++ b/Sources/BuilderCommand/main.swift
@@ -12,7 +12,7 @@ let doc = """
 Build, test, and run SwiftPM packages.
 
 Usage:
-    builder [<action>] [--configuration <config>] [--platform <platform>] [--] [<other>...]
+    builder [<action>] [--configuration <config>] [--platform <platform>] [--logs=<logs>] [--] [<other>...]
     builder (-h | --help)
 
 Arguments:
@@ -23,9 +23,7 @@ Options:
     -h, --help                      Show this text.
     -c, --configuration <config>    The configuration to build [default: debug].
     -p, --platform <platform>       The platform to build. Defaults to the current platform you're building on.
-    -logs <logs>                    Specify all log channels to enable.
-    -logs+ <logs>                   Specify additional log channels to enable.
-    -logs- <logs>                   Specify log channels to disable.
+    --logs=<logs>                   Configure logging.
 
 Examples:
     builder build --configuration release
@@ -41,6 +39,7 @@ let verbose = Logger("com.elegantchaos.builder.verbose", handlers:[PrintHandler(
 var args = Arguments(documentation: doc)
 let command = args.argument("action", default: "build")
 
+
 do {
     let configuration = try args.option("configuration")
     let platform = args.option("platform", default:Platform.currentPlatform())
@@ -51,8 +50,8 @@ do {
     error.logAndExit(output)
 } catch let error as NSError {
     output.log("Failed: \(error)")
-    exit(Int32(error.code))
+    Builder.exit(code: error.code)
 } catch {
     output.log("Failed: \(error)")
-    exit(-1)
+    Builder.exit(code: -1)
 }


### PR DESCRIPTION
Allow passing in optional full path to Info.plist. Useful for situations where the executable has a different name from the target.